### PR TITLE
Fix nobound rect error when scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rrrapha/reactour",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rrrapha/reactour",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Tourist Guide into your React Components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/TourPortal.js
+++ b/src/TourPortal.js
@@ -173,7 +173,7 @@ class TourPortal extends Component {
     const { steps } = this.props
     const { current } = this.state
     const step = steps[current]
-    if (step.follow) {
+    if (step.follow && this.helper) {
       this.showStep()
     }
   }
@@ -277,10 +277,7 @@ class TourPortal extends Component {
         },
       })
     } else {
-      if (follow && this.helper) {
-        // Helper still exists on the page, follow it
-        this.setState(setNodeState(node, this.helper, stepPosition), cb)
-      }
+      this.setState(setNodeState(node, this.helper, stepPosition), cb)
     }
   }
 

--- a/src/TourPortal.js
+++ b/src/TourPortal.js
@@ -174,15 +174,14 @@ class TourPortal extends Component {
     const { current } = this.state
     const step = steps[current]
     if (step.follow) {
-      this.showStep(false)
+      this.showStep()
     }
   }
-  showStep = (scrollToStep = true) => {
+  showStep = () => {
     const { steps } = this.props
     const { current } = this.state
     const step = steps[current]
     const node = step.selector ? document.querySelector(step.selector) : null
-
     const stepCallback = o => {
       if (step.action && typeof step.action === 'function') {
         step.action(o)
@@ -278,7 +277,10 @@ class TourPortal extends Component {
         },
       })
     } else {
-      this.setState(setNodeState(node, this.helper, stepPosition), cb)
+      if (follow && this.helper) {
+        // Helper still exists on the page, follow it
+        this.setState(setNodeState(node, this.helper, stepPosition), cb)
+      }
     }
   }
 


### PR DESCRIPTION
When the step has the `follow` property
And the user dismiss the step
And the user scrolls a page
We get an error because we don't have the step on the page anymore.

This PR fixes this by checking wether the step is on the page before performing the calculation